### PR TITLE
Add an Obfs4_get_fd function to Obfs4 transport

### DIFF
--- a/call_fd_callback.c
+++ b/call_fd_callback.c
@@ -5,8 +5,6 @@ typedef void (*fd_callback)(void *class_ptr, int);
 // bridge to allow a function pointer to be passed to go. That ptr must be called from c.
 void call_fd_callback(void* func_ptr, void* class_ptr, uintptr_t fd)
 {
-  if (func_ptr) {
-    fd_callback fd_func = (fd_callback) func_ptr;
-    fd_func(class_ptr, fd);
-  }
+  fd_callback fd_func = (fd_callback) func_ptr;
+  fd_func(class_ptr, fd);
 }

--- a/call_fd_callback.c
+++ b/call_fd_callback.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+
+typedef void (*fd_callback)(void *class_ptr, int);
+
+// bridge to allow a function pointer to be passed to go. That ptr must be called from c.
+void call_fd_callback(void* func_ptr, void* class_ptr, uintptr_t fd)
+{
+  if (func_ptr) {
+    fd_callback fd_func = (fd_callback) func_ptr;
+    fd_func(class_ptr, fd);
+  }
+}

--- a/main.go
+++ b/main.go
@@ -126,6 +126,10 @@ func Obfs4_close_connection(listener_id int) {
 
 //export Obfs4_get_fd
 func Obfs4_get_fd(listener_id int, function unsafe.Pointer, class_ptr unsafe.Pointer) int {
+  if function == nil {
+    return -1
+  }
+
   conn := tcpConns[listener_id]
   rawConn, error := conn.SyscallConn()
 

--- a/main.go
+++ b/main.go
@@ -99,7 +99,6 @@ func Obfs4_write(listener_id int, buffer unsafe.Pointer, buffer_length C.int) in
 
 //export Obfs4_read
 func Obfs4_read(listener_id int, buffer unsafe.Pointer, buffer_length int) int {
-
 	var connection = conns[listener_id]
 	header := reflect.SliceHeader{uintptr(buffer), buffer_length, buffer_length}
 	bytesBuffer := *(*[]byte)(unsafe.Pointer(&header))
@@ -119,6 +118,25 @@ func Obfs4_close_connection(listener_id int) {
 	var connection = conns[listener_id]
 	connection.Close()
 	delete(conns, listener_id)
+}
+
+//export Obfs4_get_file_descriptor
+func Obfs4_get_file_descriptor(listener_id int) int {
+  var connection = conss[listener_id]
+	value := reflect.ValueOf(connection)
+	netFD := reflect.Indirect(reflect.Indirect(value).FieldByName("fd"))
+	fd := int(netFD.FieldByName("sysfd").Int())
+	return fd
+}
+
+//export Obfs4_get_file_descriptor2
+func Obfs4_get_file_descriptor2(listener_id int) int {
+  var connection = conss[listener_id]
+	value := reflect.ValueOf(connection)
+	netFD := reflect.Indirect(reflect.Indirect(value).FieldByName("fd"))
+  pfd := reflect.Indirect(netFD.FieldByName("pfd"))
+	fd := int(pfd.FieldByName("Sysfd").Int())
+	return fd
 }
 
 func main() {}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ package main
 import "C"
 import (
 	"net"
-	//"syscall"
 	"unsafe"
 	"reflect"
 


### PR DESCRIPTION
This PR adds a get_fd function. We can do this by storing a `TCPConn` struct along with the Obfs4 `net.Conn` object. We need both (one to get the RawConn, the other to read/write data). 

I will open a few PRs upstream, but I also think that these changes are a little too specific to our use case. If they don't make it to the OperatorFoundation we can host our own repo - especially since this code does not contain most of the actual obfs4 logic. 